### PR TITLE
Change Vampiric Embrace to a utility cooldown in Classic

### DIFF
--- a/fw.lua
+++ b/fw.lua
@@ -1,6 +1,6 @@
 
 
-local dversion = 294
+local dversion = 295
 local major, minor = "DetailsFramework-1.0", dversion
 local DF, oldminor = LibStub:NewLibrary (major, minor)
 

--- a/spells.lua
+++ b/spells.lua
@@ -623,6 +623,7 @@ if (IS_WOW_PROJECT_NOT_MAINLINE) then
 	DF.CooldownsBySpec[258][19242] = 5 --desperate prayer Rank 6
 	DF.CooldownsBySpec[258][19243] = 5 --desperate prayer Rank 7
 	DF.CooldownsBySpec[258][25437] = 5 --desperate prayer Rank 8
+	DF.CooldownsBySpec[258][15286] = 5 --vampiric embrace is a debuff in classic, not a buff
 
 	--ROGUE - 259
 	DF.CooldownsBySpec[259][1857] = 2 --vanish Rank 2


### PR DESCRIPTION
Vampiric Embrace works quite differently in Classic, as it's a single target *de*buff cast on a single enemy, not a buff on the priest. I'm not sure exactly which category it should fall into, but it should not be shown as part of "Offensive player CDs" or "Defensive player CDs" on enemy nameplates, because when it's on an enemy, that means it was cast by a friendly priest. Hopefully utility is ok.

It also lasts for 60 seconds on only a 15 second cooldown, which is why it's kind of odd to call it a cooldown in this version.