### PR TITLE
Blocked ChatEdit_SendText

### DIFF
--- a/fw.lua
+++ b/fw.lua
@@ -4832,6 +4832,7 @@ end
 		["getglobal"] = true,
 		["setmetatable"] = true,
 		["DevTools_DumpCommand"] = true,
+		["ChatEdit_SendText"] = true,
 
 		--avoid creating macros
 		["SetBindingMacro"] = true,


### PR DESCRIPTION
Needs to be blocked or allows breaking out of the secure env.