### PR TITLE
Replaced single char truncate with b-search

### DIFF
--- a/fw.lua
+++ b/fw.lua
@@ -1491,6 +1491,48 @@ end
 ---@param maxWidth number
 function DF:TruncateTextSafe(fontString, maxWidth)
 	local text = fontString:GetText()
+	local numIterations = 10
+
+	while (fontString:GetStringWidth() > maxWidth) do
+		text = strsub(text, 1, #text-1)
+		fontString:SetText(text)
+		if (#text <= 1) then
+			break
+		end
+
+		numIterations = numIterations - 1
+		if (numIterations <= 0) then
+			break
+		end
+	end
+
+	text = DF:CleanTruncateUTF8String(text)
+	fontString:SetText(text)
+end
+
+---truncate removing characters from the string until the maxWidth is reach
+---@param fontString table
+---@param maxWidth number
+function DF:TruncateText(fontString, maxWidth)
+	local text = fontString:GetText()
+
+	while (fontString:GetStringWidth() > maxWidth) do
+		text = strsub(text, 1, #text - 1)
+		fontString:SetText(text)
+		if (string.len(text) <= 1) then
+			break
+		end
+	end
+
+	text = DF:CleanTruncateUTF8String(text)
+	fontString:SetText(text)
+end
+
+---truncate removing text through a binary search with a max of 10 iterations
+---@param fontString table
+---@param maxWidth number
+function DF:TruncateTextSafeBinarySearch(fontString, maxWidth)
+	local text = fontString:GetText()
 	if text == nil or text == '' then return end
 
 	if fontString:GetUnboundedStringWidth() > maxWidth then
@@ -1521,7 +1563,7 @@ end
 ---truncate removing characters from the string until the maxWidth is reach
 ---@param fontString table
 ---@param maxWidth number
-function DF:TruncateText(fontString, maxWidth)
+function DF:TruncateTextBinarySearch(fontString, maxWidth)
 	local text = fontString:GetText()
 	if text == nil or text == '' then return end
 

--- a/fw.lua
+++ b/fw.lua
@@ -1491,23 +1491,31 @@ end
 ---@param maxWidth number
 function DF:TruncateTextSafe(fontString, maxWidth)
 	local text = fontString:GetText()
-	local numIterations = 10
+	if text == nil or text == '' then return end
 
-	while (fontString:GetStringWidth() > maxWidth) do
-		text = strsub(text, 1, #text-1)
-		fontString:SetText(text)
-		if (#text <= 1) then
-			break
+	if fontString:GetUnboundedStringWidth() > maxWidth then
+		local left = 1
+		local right = #text
+		local numIterations = 10
+
+		while left <= right and numIterations > 0 do
+			local middle = math.floor((left + right) * 0.5)
+			local substring = strsub(text, 1, middle)
+			fontString:SetText(substring)
+
+			if fontString:GetUnboundedStringWidth() <= maxWidth then
+				left = middle + 1
+			else
+				right = middle - 1
+			end
+
+			numIterations = numIterations - 1
 		end
 
-		numIterations = numIterations - 1
-		if (numIterations <= 0) then
-			break
-		end
+		text = strsub(text, 1, right)
 	end
 
-	text = DF:CleanTruncateUTF8String(text)
-	fontString:SetText(text)
+	fontString:SetText(DF:CleanTruncateUTF8String(text))
 end
 
 ---truncate removing characters from the string until the maxWidth is reach
@@ -1515,17 +1523,28 @@ end
 ---@param maxWidth number
 function DF:TruncateText(fontString, maxWidth)
 	local text = fontString:GetText()
+	if text == nil or text == '' then return end
 
-	while (fontString:GetStringWidth() > maxWidth) do
-		text = strsub(text, 1, #text - 1)
-		fontString:SetText(text)
-		if (string.len(text) <= 1) then
-			break
+	if fontString:GetUnboundedStringWidth() > maxWidth then
+		local left = 1
+		local right = #text
+
+		while left <= right do
+			local middle = math.floor((left + right) * 0.5)
+			local substring = strsub(text, 1, middle)
+			fontString:SetText(substring)
+
+			if fontString:GetUnboundedStringWidth() <= maxWidth then
+				left = middle + 1
+			else
+				right = middle - 1
+			end
 		end
+
+		text = strsub(text, 1, right)
 	end
 
-	text = DF:CleanTruncateUTF8String(text)
-	fontString:SetText(text)
+	fontString:SetText(DF:CleanTruncateUTF8String(text))
 end
 
 ---@param text string
@@ -2082,8 +2101,8 @@ end
 	---* b (number|nil): The blue component of the color. This is optional if r is a string.
 	---* a (number|nil): The alpha component of the color. This is optional and defaults to 1 if not provided.
 	---* decimalsAmount (number|nil): The number of decimal places to round the color components to. This is optional and defaults to 4 if not provided.
-	---* The function returns the color in the new format. The return type depends on the newFormat parameter. It can be a string, a table, or four separate number values (for the "numbers" format). 
-	---* For the "hex" format, it returns a string representing the color in hexadecimal format.	
+	---* The function returns the color in the new format. The return type depends on the newFormat parameter. It can be a string, a table, or four separate number values (for the "numbers" format).
+	---* For the "hex" format, it returns a string representing the color in hexadecimal format.
 	---@param newFormat string
 	---@param r number|string
 	---@param g number|nil


### PR DESCRIPTION
This PR aims to change 2 things:
 - Reduce the amount attempts required to fit the string inside the font string
 - Increase the accuracy of longer texts being slimmed down when truncate safe is used

After adding the code as is, I'm not even sure the Safe version of the function is required anymore due to this method of reducing string length is much faster and requires less steps in general. I have swapped the implementation to use `GetUnboundedStringWidth` as the other one didn't seem to actually change the length at all after setting the new text value. I have not added any Lua optimizations and I'm not sure about the code style. I can adjust what's necessary or you can pull and change after, I don't mind either way.

Doing some dumping of the steps before and after to visualize the difference in how the length is calculated now:

This is `DF:TruncateTextSafe` where I set my name to repeat x times
```
10x name
start current implementation
fontstring width: 1135 , text.len 160, max width 138.83309173584
s: Linaori-RagnarosLinaori-RagnarosLinaori-RagnarosLinaori-RagnarosLinaori-RagnarosLinaori-RagnarosLinaori-RagnarosLinaori-RagnarosLinaori-RagnarosLinaori-Ragnaro
s: Linaori-RagnarosLinaori-RagnarosLinaori-RagnarosLinaori-RagnarosLinaori-RagnarosLinaori-RagnarosLinaori-RagnarosLinaori-RagnarosLinaori-RagnarosLinaori-Ragnar
s: Linaori-RagnarosLinaori-RagnarosLinaori-RagnarosLinaori-RagnarosLinaori-RagnarosLinaori-RagnarosLinaori-RagnarosLinaori-RagnarosLinaori-RagnarosLinaori-Ragna
s: Linaori-RagnarosLinaori-RagnarosLinaori-RagnarosLinaori-RagnarosLinaori-RagnarosLinaori-RagnarosLinaori-RagnarosLinaori-RagnarosLinaori-RagnarosLinaori-Ragn
s: Linaori-RagnarosLinaori-RagnarosLinaori-RagnarosLinaori-RagnarosLinaori-RagnarosLinaori-RagnarosLinaori-RagnarosLinaori-RagnarosLinaori-RagnarosLinaori-Rag
s: Linaori-RagnarosLinaori-RagnarosLinaori-RagnarosLinaori-RagnarosLinaori-RagnarosLinaori-RagnarosLinaori-RagnarosLinaori-RagnarosLinaori-RagnarosLinaori-Ra
s: Linaori-RagnarosLinaori-RagnarosLinaori-RagnarosLinaori-RagnarosLinaori-RagnarosLinaori-RagnarosLinaori-RagnarosLinaori-RagnarosLinaori-RagnarosLinaori-R
s: Linaori-RagnarosLinaori-RagnarosLinaori-RagnarosLinaori-RagnarosLinaori-RagnarosLinaori-RagnarosLinaori-RagnarosLinaori-RagnarosLinaori-RagnarosLinaori-
s: Linaori-RagnarosLinaori-RagnarosLinaori-RagnarosLinaori-RagnarosLinaori-RagnarosLinaori-RagnarosLinaori-RagnarosLinaori-RagnarosLinaori-RagnarosLinaori
s: Linaori-RagnarosLinaori-RagnarosLinaori-RagnarosLinaori-RagnarosLinaori-RagnarosLinaori-RagnarosLinaori-RagnarosLinaori-RagnarosLinaori-RagnarosLinaor
t: Linaori-RagnarosLinaori-RagnarosLinaori-RagnarosLinaori-RagnarosLinaori-RagnarosLinaori-RagnarosLinaori-RagnarosLinaori-RagnarosLinaori-RagnarosLinaor
fontstring width: 1063.3333740234 , text.len 150, max width 138.83309173584
end current implementation

10x name
start b-tree implementation
fontstring width: 1135 , text.len 160, max width 138.83309173584
s: Linaori-RagnarosLinaori-RagnarosLinaori-RagnarosLinaori-RagnarosLinaori-Ragnaros
s: Linaori-RagnarosLinaori-RagnarosLinaori-
s: Linaori-RagnarosLina
s: Linaori-Ra
s: Linaori-Ragnaro
s: Linaori-RagnarosL
s: Linaori-RagnarosLi
s: Linaori-RagnarosLin
t: Linaori-RagnarosLin
fontstring width: 134.16667175293 , text.len 19, max width 138.83309173584
end b-tree implementation

3x name
start b-tree implementation
fontstring width:  341.66668701172 , text.len 48, max width 137.99976348877
s: Linaori-RagnarosLinaori-
s: Linaori-Ragn
s: Linaori-RagnarosLi
s: Linaori-RagnarosLinao
s: Linaori-RagnarosLin
s: Linaori-RagnarosLina
t: Linaori-RagnarosLin
fontstring width: 134.16667175293 , text.len 19, max width 137.99976348877
end b-tree implementation

2x name
start b-tree implementation
fontstring width:  228.33334350586 , text.len 32, max width 137.99976348877
s: Linaori-Ragnaros
s: Linaori-RagnarosLinaori-
s: Linaori-RagnarosLina
s: Linaori-RagnarosLi
s: Linaori-RagnarosLin
t: Linaori-RagnarosLin
fontstring width: 134.16667175293 , text.len 19, max width 137.99976348877
end b-tree implementation

1x name
start b-tree implementation
fontstring width:  115.00000762939 , text.len 16, max width 137.99976348877
t: Linaori-Ragnaros
fontstring width: 115.00000762939 , text.len 16, max width 137.99976348877
end b-tree implementation
```

This is `DF:TruncateText` where I checked `/keys`
```
start current implementation
fontstring width: 137.50001525879 , text.len 22, max width 50
s: Uldaman: Legacy of Ty
s: Uldaman: Legacy of T
s: Uldaman: Legacy of 
s: Uldaman: Legacy of
s: Uldaman: Legacy o
s: Uldaman: Legacy 
s: Uldaman: Legacy
s: Uldaman: Legac
s: Uldaman: Lega
s: Uldaman: Leg
s: Uldaman: Le
s: Uldaman: L
s: Uldaman: 
s: Uldaman:
s: Uldaman
s: Uldama
t: Uldama
fontstring width: 45.833332061768 , text.len 6, max width 50
end current implementation

start current implementation
fontstring width: 95.833335876465 , text.len 17, max width 50
s: Halls of Infusio
s: Halls of Infusi
s: Halls of Infus
s: Halls of Infu
s: Halls of Inf
s: Halls of In
s: Halls of I
s: Halls of 
t: Halls of 
fontstring width: 48.333335876465 , text.len 9, max width 50
end current implementation

start b-tree implementation
fontstring width:  137.50001525879 , text.len 22, max width 50
s: Uldaman: Le
s: Uldam
s: Uldaman:
s: Uldama
s: Uldaman
t: Uldama
fontstring width: 45.833332061768 , text.len 6, max width 50
end b-tree implementation

start b-tree implementation
fontstring width:  95.833335876465 , text.len 17, max width 50
s: Halls of 
s: Halls of Infu
s: Halls of In
s: Halls of I
t: Halls of 
fontstring width: 48.333335876465 , text.len 9, max width 50
end b-tree implementation
