### PR TITLE
Default UnitGroupRolesAssigned to 'none'

### DIFF
--- a/fw.lua
+++ b/fw.lua
@@ -378,7 +378,7 @@ end
 ---@param specId number?
 ---@return string
 function DF.UnitGroupRolesAssigned(unitId, bUseSupport, specId)
-    local role
+    local role = "NONE"
 
     if (specId == 1473 and bUseSupport) then
         return "SUPPORT"


### PR DESCRIPTION
Lets this code hit the branching behavior to try to guess spec/role based on Details and/or player talents if there is no UnitGroupRolesAssigned func from Blizz