### PR TITLE
Remove duplicate entries, fix FrameStrata getters, and localize smoothing variables

### DIFF
--- a/loadconditions.lua
+++ b/loadconditions.lua
@@ -764,7 +764,6 @@ function detailsFramework:OpenLoadConditionsPanel(optionsTable, callback, frameO
 			for _, roleTable in ipairs(detailsFramework:GetRoleTypes()) do
 				local texture, l, r, t, b = detailsFramework:GetRoleIconAndCoords(roleTable.ID)
 				table.insert(roleTypes, {
-					name = (roleTable.Texture .. " " .. roleTable.Name),
 					name = roleTable.Name,
 					texture = texture,
 					texcoord = {l, r, t, b},

--- a/normal_bar.lua
+++ b/normal_bar.lua
@@ -462,7 +462,7 @@ DF:Mixin(BarMetaFunctions, DF.ScriptHookMixin)
 	end
 
 -- frame stratas
-	function BarMetaFunctions:SetFrameStrata()
+	function BarMetaFunctions:GetFrameStrata()
 		return self.statusbar:GetFrameStrata()
 	end
 	function BarMetaFunctions:SetFrameStrata(strata)

--- a/panel.lua
+++ b/panel.lua
@@ -527,7 +527,7 @@ detailsFramework.LayoutFrame = {
 	end
 
 -- frame stratas
-	function PanelMetaFunctions:SetFrameStrata()
+	function PanelMetaFunctions:GetFrameStrata()
 		return self.widget:GetFrameStrata()
 	end
 	function PanelMetaFunctions:SetFrameStrata(strata)

--- a/panel.lua
+++ b/panel.lua
@@ -3042,9 +3042,9 @@ local calc_lowess_smoothing = function(self, data, bandwidth)
 		-- For all the values in the span, compute the weight and then the linear fit
 
 		for j = jmin, jmax do
-			w = calc_cubeweight (i, j, bandwidth/2)
-			x = j
-			y = data [j]
+			local w = calc_cubeweight (i, j, bandwidth/2)
+			local x = j
+			local y = data [j]
 
 			A = A + w*x
 			B = B + w*y

--- a/spells.lua
+++ b/spells.lua
@@ -482,7 +482,6 @@ DF.CooldownsBySpec = {
 			[98008] = 4, --Spirit Link Totem
 			[108280] = 4, --Healing Tide Totem
 			[16191] = 4, --Mana Tide Totem
-			[198103] = 4, --Earth Elemental
 			[207399] = 4, --Ancestral Protection Totem (talent)
 			[198103] = 4, --Earth Elemental
 			[65992] = 5, --Tremor Totem
@@ -846,7 +845,6 @@ DF.CooldownsInfo = {
 	[198589] = {cooldown = 60, duration = 10, talent = false, charges = 1, class = "DEMONHUNTER", type = 2}, --Blur
 
 	[196555] = {cooldown = 120, duration = 5, talent = 21865, charges = 1, class = "DEMONHUNTER", type = 2}, --Netherwalk (talent)
-	[196718] = {cooldown = 180, duration = 8, talent = false, charges = 1, class = "DEMONHUNTER", type = 4}, --Darkness
 	[187827] = {cooldown = 180, duration = 15, talent = false, charges = 1, class = "DEMONHUNTER", type = 2}, --Metamorphosis
 	[196718] = {cooldown = 180, duration = 8, talent = false, charges = 1, class = "DEMONHUNTER", type = 4}, --Darkness
 	[188501] = {cooldown = 30, duration = 10, talent = false, charges = 1, class = "DEMONHUNTER", type = 5}, --Spectral Sight
@@ -909,7 +907,6 @@ DF.CooldownsInfo = {
 	[199754] = {cooldown = 120, duration = 10, talent = false, charges = 1, class = "ROGUE", type = 2},  --Riposte
 	[121471] = {cooldown = 180, duration = 20, talent = false, charges = 1, class = "ROGUE", type = 1},  --Shadow Blades
 	[343142] = {cooldown = 90, duration = 10, talent = 19250, charges = 1, class = "ROGUE", type = 5},  --Dreadblades
-	[121471]  = {cooldown = 180, duration = 20, talent = false, charges = 1, class = "ROGUE", type = 1},  --Shadow Blades
 }
 
 -- {cooldown = , duration = , talent = false, charges = 1}


### PR DESCRIPTION
This pull request cleans up several minor issues across the framework to improve code clarity and prevent unexpected behavior:

- **loadconditions.lua**  
  - Removed a redundant `name` field in the `roleTypes` table to eliminate duplicate keys.  

- **normal_bar.lua & panel.lua**  
  - Fixed mixin definitions so that `GetFrameStrata()` properly returns the strata instead of being aliased to `SetFrameStrata()`.  

- **panel.lua (Lowess smoothing)**  
  - Localized loop variables (`w`, `x`, `y`) in the `calc_lowess_smoothing` function to prevent accidental global scope pollution.  

- **spells.lua & cooldown definitions**  
  - Eliminated duplicate spell ID entries in both `CooldownsBySpec` and `CooldownsInfo` tables to avoid overwriting data.

No behavior changes are expected—this is purely a behind-the-scenes cleanup to make future maintenance smoother.
