### PR TITLE
Updated encounter IDs for Midnight season 1

### DIFF
--- a/fw.lua
+++ b/fw.lua
@@ -5498,16 +5498,15 @@ end
 
 -- TODO: maybe make this auto-generaded some day?...
 DF.CLEncounterID = {
-	{ID = 2423, Name = "The Tarragrue"},
-	{ID = 2433, Name = "The Eye of the Jailer"},
-	{ID = 2429, Name = "The Nine"},
-	{ID = 2432, Name = "Remnant of Ner'zhul"},
-	{ID = 2434, Name = "Soulrender Dormazain"},
-	{ID = 2430, Name = "Painsmith Raznal"},
-	{ID = 2436, Name = "Guardian of the First Ones"},
-	{ID = 2431, Name = "Fatescribe Roh-Kalo"},
-	{ID = 2422, Name = "Kel'Thuzad"},
-	{ID = 2435, Name = "Sylvanas Windrunner"},
+	{ID = 3176, Name = "Imperator Averzian"},
+	{ID = 3177, Name = "Vorasius"},
+	{ID = 3179, Name = "Fallen-King Salhadaar"},
+	{ID = 3178, Name = "Vaelgor & Ezzorak"},
+	{ID = 3180, Name = "Lightblinded Vanguard"},
+	{ID = 3181, Name = "Crown of the Cosmos"},
+	{ID = 3306, Name = "Chimaerus the Undreamt God"},
+	{ID = 3182, Name = "Belo'ren, Child of Al'ar"},
+	{ID = 3183, Name = "Midnight Falls"},
 }
 
 function DF:GetPlayerRole()


### PR DESCRIPTION
Updated encounter IDs for Midnight season 1. The order of encounters is the same as their appear in the dungeon journal, which seems most natural to me. This is a quick fix, until I can come up with a way to dynamically get this information.

These values are used in a tooltip in Plater. See image below.

<img width="1051" height="642" alt="image" src="https://github.com/user-attachments/assets/e8adebca-1f82-4601-ab5f-e45228b777a4" />
